### PR TITLE
Update parser.js

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -177,10 +177,11 @@
                 var typeInfo = fieldName.split(';');
                 fieldName = typeInfo[0];
                 fieldTypeInfo = typeInfo.slice(1).map(function (type) {
-                    var info = type.split('=');
+                    let info = type.split('=');
+
                     return {
-                        name: info[0].toLowerCase(),
-                        value: info[1].replace(/"(.*)"/, '$1')
+                        name: info[0]?.toLowerCase(),
+                        value: info[1]?.replace(/"(.*)"/, '$1')
                     }
                 });
             }


### PR DESCRIPTION
Modified Nullreference intercepted

Different examples of vCard strings crash while being parsed, because of missing values. 
I added a null check. 